### PR TITLE
Method to Change window title

### DIFF
--- a/Geometria/Graphics/Cores/MainAPI/Graphics.cpp
+++ b/Geometria/Graphics/Cores/MainAPI/Graphics.cpp
@@ -191,6 +191,13 @@ void Graphics::SetResizeCall()
 	}
 }
 
+void Graphics::SetWindowTitle(const char* title)
+{
+	//==[ OPENGL ]==//
+	{
+		glfwSetWindowTitle(_currentWindow.openGLWindow, title);
+	}
+}
 
 void Graphics::EnableDraggableBorderless()
 {

--- a/Geometria/Graphics/Cores/MainAPI/Graphics.h
+++ b/Geometria/Graphics/Cores/MainAPI/Graphics.h
@@ -47,6 +47,7 @@ public:
 	static void SetCursor();
 	static void GetFrameBuffer();
 	static void SetResizeCall();
+	static void SetWindowTitle(const char* title);
 	static bool VSync;
 
 	static void SetResolution(Vector2 resolution)


### PR DESCRIPTION
Didn't feel right to not give an option to set the window title from `GameMain` so i quickly added a method in `Graphics` to abstract the glfw stuff

![image](https://user-images.githubusercontent.com/62946885/181816065-b0352152-e7b2-4459-8a2b-09ac97fc1380.png)
