### PR TITLE
[0.2.5] Adding offset to BoxCollider

### DIFF
--- a/Geometria/Physics/Colliders/BoxCollider.cpp
+++ b/Geometria/Physics/Colliders/BoxCollider.cpp
@@ -43,7 +43,7 @@ void BoxCollider::OnTransformChange(int value)
 		case 0:
 			if(boxStatic != nullptr)
 			{
-				boxStatic->setGlobalPose(physx::PxTransform(GetTransform().position.x, GetTransform().position.y, GetTransform().position.z));
+				boxStatic->setGlobalPose(physx::PxTransform(GetTransform().position.x + offset.x, GetTransform().position.y + offset.y, GetTransform().position.z + offset.z));
 			}
 			break;
 
@@ -139,6 +139,11 @@ void BoxCollider::SetScale(Vector3 size)
 
 		boxStatic->attachShape(*boxShape);
 	}
+}
+
+void BoxCollider::SetOffset(Vector3 offset)
+{
+	this->offset = offset;
 }
 
 void BoxCollider::SetTrigger(bool t)

--- a/Geometria/Physics/Colliders/BoxCollider.h
+++ b/Geometria/Physics/Colliders/BoxCollider.h
@@ -23,6 +23,7 @@ struct BoxCollider : public ScriptBehaviour
 	physx::PxShape* boxShape = nullptr;
 
 	Vector3 size = Vector3(1);
+	Vector3 offset = Vector3(0);
 
 	bool _isTrigger = false;
 
@@ -43,5 +44,6 @@ struct BoxCollider : public ScriptBehaviour
 	void OnDestroy();
 	void OnTransformChange(int value);
 	void SetScale(Vector3 size);
+	void SetOffset(Vector3 offset);
 	void SetTrigger(bool t);
 };

--- a/Geometria/Physics/Rigidbody/Rigidbody.cpp
+++ b/Geometria/Physics/Rigidbody/Rigidbody.cpp
@@ -15,10 +15,11 @@ void Rigidbody::OnUpdate()
 	{
 		if (boxC->boxDynamic != nullptr)
 		{
+			Vector3 offset = boxC->offset;
 			if (!forceChange)
 			{
 				physx::PxTransform t = boxC->boxDynamic->getGlobalPose();
-				physx::PxVec3 pos = t.p;
+				physx::PxVec3 pos = physx::PxVec3(t.p.x - offset.x, t.p.y - offset.y, t.p.z - offset.z);
 
 				if (freezePositionX)
 				{
@@ -40,6 +41,7 @@ void Rigidbody::OnUpdate()
 
 				GetTransform().position = Vector3(pos.x, pos.y, pos.z);
 				forcedTransform.position = GetTransform().position;
+				boxC->boxDynamic->setGlobalPose(physx::PxTransform(pos.x + offset.x, pos.y + offset.y, pos.z + offset.z));
 			}
 			else
 			{


### PR DESCRIPTION
# BoxCollider offset

## How to use?
Simply call `SetOffset()` with a BoxCollider, and a Vector3 parameter for how much to offset the hitbox.

Example:
```cpp
// This will create a Model with a BoxCollider and then offset its BoxCollider by 1 unit to the right.
Model* player = new Model(Model::Primitives::SQUARE, Vector3(0), Vector3(0), Vector3(1));
player->AddScript<RigidBody>();
player->AddScript<BoxCollider>();

player->GetScript<BoxCollider>()->SetOffset(Vector3(1, 0, 0));
```